### PR TITLE
Add rudimentary full-text search to SRTracker.

### DIFF
--- a/templates/_results_list.html
+++ b/templates/_results_list.html
@@ -1,0 +1,21 @@
+{% block content %}
+	{% if service_requests %}
+		<div class="box request_list">
+			<h1>Results</h1>
+			<table>
+				<tbody>
+					{# most recent requests first, in order #}
+					{% for sr in service_requests|sort(reverse=True, attribute='requested_datetime') %}
+						{% if sr.service_request_id %}
+							<tr>
+								<th><a href="{{ url_for("show_request", request_id=sr.service_request_id) }}">{{ sr.service_name or '?' }}</a></th>
+								<td class="number_col"><a href="{{ url_for("show_request", request_id=sr.service_request_id) }}">#{{ sr.service_request_id }}</a></td>
+								<td class="number_col time_col"><a href="{{ url_for("show_request", request_id=sr.service_request_id) }}">{{ sr.requested_datetime|friendly_time }}</a></td>
+							</tr>
+						{% endif %}
+					{% endfor %}
+				</tbody>
+			</table>
+		</div>
+	{% endif %}
+{% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block page_class %}landing{% endblock %}
+
+{% block stylesheets %}
+	{{ super() }}
+	<style type="text/css" media="screen">
+		body {
+			background: #a4d2de url("{{ url_for("static", filename="img/sr_icons.png") }}");
+			margin: 0;
+			font-family: Helvetica, Arial, sans-serif;
+		}
+	</style>
+{% endblock %}
+
+{% block scripts %}
+	{{ super() }}
+	<script type="text/javascript">
+		if (window.matchMedia) {
+			$(document).ready(function() {
+				if (matchMedia("only screen and (max-width: 759px)").matches) {
+					$("#search_field").attr("placeholder", "Enter service request #");
+				}
+			});
+		}
+	</script>
+{% endblock %}
+
+{% block page_header %}<span class="site_title">311 Chicago Service Tracker: Request Search</span>{% endblock %}
+
+{% block content %}
+	<div class="main_content">
+		<div class="box">
+			<h1>Search 311 service requests</h1>
+
+			<form method="GET" action="{{ url_for('request_search') }}" class="in_yo_face search_form">
+				<input type="text" name="q" id="search_field" class="search_field" placeholder="description, SR number, etc" />
+				<input type="submit" class="submit" value="Submit" />
+			</form>
+		</div>
+		
+                {% include "_results_list.html" %}
+
+	</div>
+{% endblock %}


### PR DESCRIPTION
(See https://github.com/codeforamerica/srtracker/issues/48#issuecomment-9726503 as well.)

Group effort at Open Gov Hack Night in Chicago, with
Rob Brackett, Forest Gregg, Derek Eder, Tom Kompare,
Patrick Nguyen, Karl Fogel.  Suggested by Juan-Pablo Velez.
- app.py
  (search): New function, new routes.
  (request_search): Pass off to search() based on request parameter.
- templates/_results_list.html,
  templates/search.html: New templates.
