### PR TITLE
Cut off long service names with an ellipsis

### DIFF
--- a/static/css/service_request.css
+++ b/static/css/service_request.css
@@ -61,6 +61,12 @@ h1 {
 	font-family: ArvoBold, Helvetica, Arial, sans-serif;
 	font-size: 32px;
 	font-weight: normal;
+	overflow: hidden;
+     -o-text-overflow: ellipsis;
+    -ms-text-overflow: ellipsis;
+   -moz-text-overflow: ellipsis;
+-webkit-text-overflow: ellipsis;
+        text-overflow: ellipsis;
 }
 
 input {


### PR DESCRIPTION
This prevents the page from scrolling when it shouldn't and fixes #33.
