### PR TITLE
Remove logging of all retrieved SRs

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,8 +64,6 @@ def index():
     if app.config['OPEN311_API_KEY']:
         params['api_key'] = app.config['OPEN311_API_KEY']
 
-    app.logger.debug('RECENT SRs: %s', params)
-
     r = requests.get(url, params=params)
     if r.status_code != 200:
         app.logger.error('OPEN311: Failed to load recent requests from Open311 server. Status Code: %s, Response: %s', r.status_code, r.text)


### PR DESCRIPTION
All this logging was a little more than reasonably necessary. For some reason, I had been thinking there was more like this, but maybe we've cleaned some of it out since I originally made the bug for it. This was the only thing I found that seemed like it was unreasonable :P

Fixes #58.
