### PR TITLE
[Issue #75] On very skinny screens, photo and descriptions should stack

### DIFF
--- a/static/css/service_request.css
+++ b/static/css/service_request.css
@@ -76,9 +76,12 @@ input {
 .request_details {
 	position: relative;
 	margin-bottom: 32px;
-	padding: 24px;
+	padding: 24px 160px 24px 24px;
 	background: #f0f0f0;
 	box-shadow: 0 5px 5px rgba(0, 0, 0, 0.07);
+}
+.request_details.has_media {
+	padding-right: 320px;
 }
   .request_info {
     float: left;
@@ -86,6 +89,7 @@ input {
 	.request_media {
 		float: right;
 		max-width: 280px;
+		margin: 0 -300px 0 0;
 	}
 
 	.status_indicator {
@@ -322,11 +326,14 @@ input {
 		margin-bottom: 32px;
 		padding: 10px;
 	}
+	.request_details.has_media {
+		padding: 10px;
+	}
 		.request_media {
 			max-width: 100%;
 			margin: 0 0 0.5em;
-      float: left;
-      clear: left;
+			float: left;
+			clear: left;
 		}
 	
 		.status_indicator {

--- a/templates/service_request.html
+++ b/templates/service_request.html
@@ -18,37 +18,39 @@
 			
 			<p class="status_indicator status-{{ sr.status }}">{{ sr.status.title() }}</p>
 			
-      <div class='request_info'>
-        <div class="request_id">#{{ sr.service_request_id }}</div>
+			<div class='request_info'>
+				<div class="request_id">#{{ sr.service_request_id }}</div>
 
-        {% if 'description' in sr %}
-          <p><strong>Description:</strong> {{ sr.description }}</p>
-        {% endif %}
+				{% if 'description' in sr %}
+					<p><strong>Description:</strong> {{ sr.description }}</p>
+				{% endif %}
 
-        <p>
-          <strong>Address:</strong> 
-          {% if sr.address %}
-            {{ sr.address|title_address }}
-          {% else %}
-            Unknown
-          {% endif %}
-        </p>
-        <p>
-          <strong>Created:</strong> 
-          {% if sr.requested_datetime %}
-            {{ sr.requested_datetime.strftime('%B %d, %Y') }}
-          {% else %}
-            Unknown
-          {% endif %}
-        </p>
-        {%  if sr.extended_attributes and sr.extended_attributes.channel %}
-          <p><strong>Received via:</strong> {{ sr.extended_attributes.channel.title() }}</p>
-        {% endif %}
-      </div>
-      <img src="http://311request.cityofchicago.org/media/chicago/report/photos/521b5b4a016302a7830f3e25/pic_9246_2531.png" class="request_media" alt="">
+				<p>
+					<strong>Address:</strong> 
+					{% if sr.address %}
+						{{ sr.address|title_address }}
+					{% else %}
+						Unknown
+					{% endif %}
+				</p>
+				<p>
+					<strong>Created:</strong> 
+					{% if sr.requested_datetime %}
+						{{ sr.requested_datetime.strftime('%B %d, %Y') }}
+					{% else %}
+						Unknown
+					{% endif %}
+				</p>
+				{%  if sr.extended_attributes and sr.extended_attributes.channel %}
+					<p><strong>Received via:</strong> {{ sr.extended_attributes.channel.title() }}</p>
+				{% endif %}
+			</div>
+			{% if sr.media_url %}
+				<img src="{{ sr.media_url }}" class="request_media" alt="" />
+			{% endif %}
 			<div class="clearfix"></div>
 		</div>
-
+		
 		<div class="secondary_content">
 			<section class="request_history">
 				<h2 class="activity_header">Activity</h2>


### PR DESCRIPTION
Hi!

I notice the issue #75 and made an adjustment on the css so the image on a view from a service request would fall under the service request information when viewing on small screens. I tested it on an ipad and iphone but would like to know what you guys think. I am open to any feedback if you guys want me to change anything. 

Hope it helps! 
