### PR TITLE
Show version number in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Release History
+
+The following is a history of the major changes included in various releases of Service Request Tracker.
+
+
+## 1.0.2 (2012-09-10)
+
+- New icons!
+- Fix erroneous display of “under review” activities.
+- Add support for configuring the app and updater via environment variables or a file called `configuration.py`.
+- Enable updater script to be configured with command-line arguments.
+- Home page displays requests in order, most recently updated first.
+- Ability to suppress the display of certain fields from a service request.
+- Add footer with extra info and links to the bottom of every page.
+- Minor display tweaks.
+
+
+## 1.0.1 (2012-08-22)
+
+- Add support for finalized version of Chicago’s Open311 API.
+- Fix error when e-mail is improperly configured.
+- Fix infinite redirect problem when searching for service requests.
+
+
+## 1.0 (2012-08-20)
+
+Initial release!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,20 @@ The following is a history of the major changes included in various releases of 
 ## 1.0 (2012-08-20)
 
 Initial release!
+
+
+---
+
+## (In-progress work)
+
+- Integration with Google Analytics
+- Show a dot in the activity list noting when a request was completed/closed.
+- Fix broken images on retina displays.
+- RSS/Atom feed for service request updates!
+- You can now filter the home page by service request type.
+- Special thanks to new contributors:
+  - Philip Neustrom (https://github.com/philipn)
+  - Ryan Briones (https://github.com/ryanbriones)
+  - Karl Fogel (https://github.com/kfogel)
+  - Thomas Caswell (https://github.com/tacaswell)
+  - Dave Guarino (https://github.com/daguar)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ It includes the following components:
  - A web application for listing service requests, searching for a specific service request based on ID, and subscribing to email updates for specific service requests
  - A python script (in `/updater`) that checks the Open311 endpoint for 
 
+The latest version is **1.0.2**.
+
 ![Screenshot of SR Tracker](https://raw.github.com/codeforamerica/srtracker/master/screenshot.png)
 
 

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ import updater
 
 import open311tools
 
+__version__ = '1.0.2'
 
 # Config
 DEFAULT_CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'configuration.py')

--- a/app.py
+++ b/app.py
@@ -413,6 +413,8 @@ def render_app_template(template, **kwargs):
 
     if 'config' not in kwargs:
         kwargs['config'] = app.config
+    if '__version__' not in kwargs:
+        kwargs['__version__'] = __version__
     return render_template(template, **kwargs)
 
 

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -235,6 +235,14 @@ button:hover {
 			width: 133px;
 			background-image: url("../img/footer_logo_cfa.png");
 		}
+	
+	.version_number {
+		margin: 2em 0 0;
+		padding: 0;
+		font-size: 0.8em;
+		color: #999;
+		clear: left;
+	}
 
 .message_overlay_backing {
 	position: fixed;
@@ -347,7 +355,7 @@ button:hover {
 
 @media only screen and (max-width: 759px) {
 	body {
-		padding: 0 0 180px;
+		padding: 0 0 220px;
 	}
 
 	.landing .page_header {

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -10,18 +10,20 @@
 		<a href="http://cityofchicago.org/" class="logo logo_chicago">City of Chicago</a>
 		<a href="http://codeforamerica.org/" class="logo logo_cfa">Code for America</a>
 	</div>
+	
+	<p class="version_number">Version {{ __version__ }}</p>
 
 	{% if config.GOOGLE_ANALYTICS_ACCOUNT %}
 		<script type="text/javascript">
-		  var _gaq = _gaq || [];
-		  _gaq.push(['_setAccount', '{{ config.GOOGLE_ANALYTICS_ACCOUNT }}']);
-		  _gaq.push(['_trackPageview']);
+			var _gaq = _gaq || [];
+			_gaq.push(['_setAccount', '{{ config.GOOGLE_ANALYTICS_ACCOUNT }}']);
+			_gaq.push(['_trackPageview']);
 
-		  (function() {
-		    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-		    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-		    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-		  })();
+			(function() {
+				var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+				ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+				var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+			})();
 		</script>
 	{% endif %}
 </footer>


### PR DESCRIPTION
Quickie implementation of @bensheldon’s suggestion in #78.

Here’s how it looks right now on large and small screens:

![version_number_preview](https://cloud.githubusercontent.com/assets/74178/5667485/c58dec9c-972d-11e4-9b75-c7cfe82556ca.png)

Happy to modify if anybody has feedback.
